### PR TITLE
updated kirbi2john.py

### DIFF
--- a/kirbi2john.py
+++ b/kirbi2john.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3 -tt
+#!/usr/bin/env python3
 # Based on the Kerberoast script from Tim Medin to extract the Kerberos tickets
 # from a kirbi file.
 # Modification to parse them into the JTR-format by Michael Kramer (SySS GmbH)

--- a/kirbi2john.py
+++ b/kirbi2john.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S python3 -tt
 # Based on the Kerberoast script from Tim Medin to extract the Kerberos tickets
 # from a kirbi file.
 # Modification to parse them into the JTR-format by Michael Kramer (SySS GmbH)


### PR DESCRIPTION
due to "/usr/bin/env python -tt" in shebang. kirbi2john.py was not running to fix this I have removed the '-tt'  from shebeng line.

Error picture: 
![error](https://i.ibb.co/7jJsYry/error-kirbi2john.png)